### PR TITLE
adds new cli package

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Build wheel packages
         if: ${{ ! contains(matrix.os, 'windows') }}
         run: |
-          python make.pyz beta-release -v
+          python make.pyz beta-build -v
           touch .keepme
 
       - name: "Publish beta package to pypi"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ Please, use the format:
 - beta-builder: automatically publish beta packages into pypi from main branch
 - improve debug logging
 - fix issues encountered with PR #11
+- adds a new luxos.cli package

--- a/src/luxos/cli/v1.py
+++ b/src/luxos/cli/v1.py
@@ -1,0 +1,156 @@
+"""cli utilities
+
+This adds a `cli` decorator to make easier to write consistent scripts.
+
+It adds:
+    -v/--verbose/-q/--quiet flags to increase the logging verbosity level
+    -c/--config to pass a config file (default to config.yaml)
+
+Eg. in your script
+    from luxos_firmware.cli.v1 import cli
+
+    # this is the plain calling function
+    @cli()
+    def main(args):
+        ... args is a argparse.Namespace
+
+    # This call allows to add arguments to the parser
+
+    def add_arguments(parser):
+        parser.add_argument(....
+
+    def process_args(args):
+        ...
+
+    @cli(add_arguments, process_args)
+    @def main(args):
+        ... args is a argparse.Namespace
+
+    # finally this will let you control the parser
+    @cli()
+    def main(parser):
+        parser.add_argument()
+        args = parser.parse_args()
+"""
+
+from __future__ import annotations
+
+import contextlib
+import inspect
+import logging
+import time
+from pathlib import Path
+import functools
+import argparse
+
+# SPECIAL MODULE LEVEL VARIABLES
+MODULE_VARIABLES = {
+    "LOGGING_CONFIG": None,
+}
+
+
+log = logging.getLogger(__name__)
+
+
+class LuxosParser(argparse.ArgumentParser):
+    def __init__(self, module_variables, *args, **kwargs):
+        self.module_variables = module_variables or {}
+        super().__init__(*args, **kwargs)
+        self.add_argument(
+            "-v", "--verbose", action="count", help="report verbose logging"
+        )
+        self.add_argument("-q", "--quiet", action="count", help="report quiet logging")
+        self.add_argument(
+            "-c",
+            "--config",
+            default=Path("config.yaml"),
+            type=Path,
+            help="load yaml config file",
+        )
+
+    def parse_args(self, args=None, namespace=None):
+        options = super().parse_args(args, namespace)
+        options.error = self.error
+
+        # set the logging level
+        count = (options.verbose or 0) - (options.quiet or 0)
+        level = {
+            1: logging.DEBUG,
+            0: logging.INFO,
+            -1: logging.WARNING,
+        }[max(min(count, 1), -1)]
+
+        module_variables = self.module_variables
+        config = {}
+        if value := module_variables.get("LOGGING_CONFIG"):
+            config = value.copy()
+        config["level"] = level
+        logging.basicConfig(**config)
+
+        return options
+
+    @classmethod
+    def get_parser(cls, module_variables):
+        class Formatter(
+            argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter
+        ):
+            pass
+
+        return cls(module_variables=module_variables, formatter_class=Formatter)
+
+
+def cli(add_arguments=None, process_args=None):
+    def _cli1(function):
+        @contextlib.contextmanager
+        def setup():
+            sig = inspect.signature(function)
+
+            module_variables = MODULE_VARIABLES.copy()
+            module = inspect.getmodule(function)
+            for name in list(module_variables):
+                module_variables[name] = getattr(module, name, None)
+
+            if "args" in sig.parameters and "parser" in sig.parameters:
+                raise RuntimeError("cannot use args and parser at the same time")
+
+            kwargs = {}
+            parser = LuxosParser.get_parser(module_variables)
+            if add_arguments:
+                add_arguments(parser)
+
+            if "parser" in sig.parameters:
+                kwargs["parser"] = parser
+
+            t0 = time.monotonic()
+            success = "completed"
+            try:
+                if "parser" not in sig.parameters:
+                    args = parser.parse_args()
+                    if process_args:
+                        args = process_args(args) or args
+                    if "args" in sig.parameters:
+                        kwargs["args"] = args
+                yield sig.bind(**kwargs)
+            except Exception:
+                log.exception("un-handled exception")
+                success = "failed"
+            finally:
+                delta = round(time.monotonic() - t0, 2)
+                log.info("task %s in %.2fs", success, delta)
+
+        if inspect.iscoroutinefunction(function):
+
+            @functools.wraps(function)
+            async def _cli2(*args, **kwargs):
+                with setup() as ba:
+                    return await function(*ba.args, **ba.kwargs)
+        else:
+
+            @functools.wraps(function)
+            def _cli2(*args, **kwargs):
+                with setup() as ba:
+                    return function(*ba.args, **ba.kwargs)
+
+        return _cli2
+
+    return _cli1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,31 @@
+import argparse
+import sys
+from unittest import mock
+
+from luxos.cli import v1 as cli
+
+
+def test_docstring():
+    @cli.cli()
+    def hello():
+        "this is a docstring"
+        pass
+
+    assert hello.__doc__ == "this is a docstring"
+
+
+def test_callme():
+    @cli.cli()
+    def main(parser):
+        assert isinstance(parser, argparse.ArgumentParser)
+
+    main()
+
+    args = ["dummy.py"]
+    with mock.patch.object(sys, "argv", args):
+
+        @cli.cli()
+        def main2(args):
+            assert isinstance(args, argparse.Namespace)
+
+        main2()


### PR DESCRIPTION
## Description

This changeset will:

- add a new cli package
- fix minor issues


### add a new cli package

This provides a simple `cli` decorator to help maintain a consistent cli experience across scripts:

- have a -v/--verbose/-q/--quiet flag to report logging at different levels (by default only log.info/log.warning/log.exception)
- writing a logfile `LuxOS-LoadControl.log` (if LOGGING_CONFIG  is not defined, it will default to stderr)


#### Simplest usage
```
import logging
from luxos_firmware.cli.v1 import cli

# <- this will be used to setup the logging, you can skip for a default configuration
LOGGING_CONFIG = {
    'format': "%(asctime)s [%(levelname)s] %(message)s",
    'handlers':
    [logging.StreamHandler(),
     logging.FileHandler("LuxOS-LoadControl.log")],
}

log = logging.getLogger(__name__)

@cli()
def main():
    log.debug("a debug message")
    log.info("an info message")
    log.warning("a warning message")

if __name__ == "__main__":
    main()

# eg. python main.py -v:
# 2024-04-08 11:21:25,365 [DEBUG] a debug message
# 2024-04-08 11:21:25,365 [INFO] an info message
# 2024-04-08 11:21:25,366 [WARNING] a warning message
# 2024-04-08 11:21:25,366 [INFO] task completed in 0.00s
```

#### add and postprocess arguments
This shows how to add new arguments, and postprocessing them:

```
import logging
import argparse
from luxos_firmware.cli.v1 import cli

log = logging.getLogger(__name__)

def add_arguments(parser: argparse.ArgumentParser) -> None:
    parser.add_argument("-x", dest="counter", action="count")

def process_args(args: argparse.Namespace) -> None | argparse.Namespace:
    args.counter *= 2

@cli(add_arguments, process_args)
def main(args):
    log.info("got %s", args.counter)

if __name__ == "__main__":
    main()

# eg. python main.py -x -x -x:
# INFO:__main__:got 6
# INFO:luxos_firmware.cli.v1:task completed in 0.00s
```






## Merge request checklist

- [x] Added the appropriate `bug`, `enhancement` and/or `breaking-change` tags
- [x] My code passes all tests, linter and formatting checks (`make check`).
- [x] My commits follow the [How to Write a Git Commit Message Guide](https://chris.beams.io/posts/git-commit/).
- [x] I have updated the `CHANGELOG` (yeah, last chance to do it).
- [x] Run the `python make.py onepack` and add the new luxos.pyz/health-checker.pyz 
     generated files
