### PR TITLE
post 0.0.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,16 @@ Please, use the format:
 
 ## [Unreleased]
 
+
+## [0.0.9]
+
+- asyncops: standardize module level variables TIMEOUT/RETRIES/RETRIES_DELAY
+- asyncops: re-raise timeouts with the correct exception MinerCommandTimeoutError
+- cli: handle flags for rexec (TIMEOUT/RETRIES/RETRIES_DELAY)
 - cli: new log format
 - cli: better support for exceptions captured in cli.cli
 - utils: launch uses a base LuxosLaunchError for all exceptions
+
 
 ## [0.0.8]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Please, use the format:
 
 -->
 
+## [Unreleased]
+
+- cli: new log format
+- cli: better support for exceptions captured in cli.cli
+- utils: launch uses a base LuxosLaunchError for all exceptions
+
 ## [0.0.8]
 
 - added a new cli.flags module to handle range flags (eg. allowing 127.0.0.1-127.0.0.9 ranges)

--- a/docs/api/examples/simple2.py
+++ b/docs/api/examples/simple2.py
@@ -15,8 +15,11 @@ Example:
 
 import argparse
 import asyncio
+import logging
 
 import luxos.cli.v1 as cli
+
+log = logging.getLogger(__name__)
 
 
 def add_arguments(parser: argparse.ArgumentParser) -> None:
@@ -45,6 +48,23 @@ def process_args(args: argparse.Namespace) -> argparse.Namespace | None:
 async def main(args: argparse.Namespace):
     """a simple test script with a simple description"""
 
+    # many ways to abort a script
+    # 1. raising various exceptions
+    #     (dump a stack trace)
+    #     >>> raise RuntimeError("aborting")
+    #     (dump a nice error message on the cli)
+    #     >>> raise cli.AbortWrongArgument("a message)
+    #     (abort unconditionally the application)
+    #     >>> raise cli.AbortCliError("abort")
+    # 2. using args.error (nice cli error message)
+    #     >>> args.error("too bad")
+
+    # logging to report messages
+    log.debug("a debug message")
+    log.info("an info message")
+    log.warning("a warning message")
+
+    # handle the args
     if args.range:
         print("args.range")
         for host, port in args.range or []:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "luxos"
-version = "0.0.8"
+version = "0.0.9"
 description = "The all encompassing LuxOS python library."
 readme = "README.md"
 license = { text = "MIT" }  # TODO I don't think this is a MIT??

--- a/src/luxos/api.py
+++ b/src/luxos/api.py
@@ -23,6 +23,8 @@ def logon_required(cmd: str, commands_list=COMMANDS) -> bool | None:
 
 
 # TODO timeouts should be float | None
+# TODO prepare for refactoring using example in
+#      tests.test_asyncops.test_bridge_execute_command
 def execute_command(
     host: str, port: int, timeout: int, cmd: str, params: list[str], verbose: bool
 ):

--- a/src/luxos/cli/flags.py
+++ b/src/luxos/cli/flags.py
@@ -51,18 +51,36 @@ def type_hhmm(txt: str):
 
 
 def add_arguments_rexec(parser: argparse.ArgumentParser) -> None:
+    """adds the rexec timing for timeout/retries/delays
+
+    Ex.
+
+    def add_arguments(parser):
+        cli.flags.add_arguments_rexec(parser)
+
+    def process_args(args):
+        asyncops.TIMEOUT = args.timeout
+        asyncops.RETRIES = args.retries
+        asyncops.RETRIES_DELAY = args.retries_delay
+        return args
+    """
+    from ..asyncops import RETRIES, RETRIES_DELAY, TIMEOUT
+
     group = parser.add_argument_group(
         "Remote execution", "rexec remote execution limits/timeouts"
     )
     group.add_argument(
-        "--timeout", type=float, default=3.0, help="Timeout for each command"
+        "--timeout", type=float, default=TIMEOUT, help="Timeout for each command"
     )
     group.add_argument(
-        "--max-retries",
+        "--retries",
         type=int,
-        default=3,
+        default=RETRIES,
         help="Maximum number of retries for each command",
     )
     group.add_argument(
-        "--delay-retry", type=float, default=3.0, help="Delay in s between retries"
+        "--retries-delay",
+        type=float,
+        default=RETRIES_DELAY,
+        help="Delay in s between retries",
     )

--- a/src/luxos/exceptions.py
+++ b/src/luxos/exceptions.py
@@ -1,3 +1,6 @@
+import asyncio
+
+
 class LuxosBaseException(Exception):
     pass
 
@@ -18,7 +21,7 @@ class MinerCommandSessionAlreadyActive(MinerConnectionError):
     pass
 
 
-class MinerCommandTimeoutError(MinerConnectionError):
+class MinerCommandTimeoutError(MinerConnectionError, asyncio.TimeoutError):
     pass
 
 

--- a/src/luxos/utils.py
+++ b/src/luxos/utils.py
@@ -52,14 +52,15 @@ async def launch(
 
     Special kwargs:
         - batch execute operation in group of batch tasks (rate limiting)
-        - naked do not wrap the call (default None)
+        - naked do not wrap the call, so is up to you catching exceptions (default None)
 
     Eg.
         async printme(host, port, value):
             print(await rexec(host, port, "version"))
         asyncio.run(launch([("127.0.0.1", 4028)], printme, value=11, batch=10))
     """
-    # special kwargs!!
+
+    # a naked options, wraps the 'call' and re-raise exceptions as LuxosLaunchError
     naked = kwargs.pop("naked") if "naked" in kwargs else None
 
     def wraps(fn):

--- a/src/luxos/utils.py
+++ b/src/luxos/utils.py
@@ -3,14 +3,23 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 from typing import Any, Callable
 
 import luxos.misc
+from luxos.asyncops import rexec  # noqa: F401
 
 # we bring here functions from other modules
-from luxos.asyncops import rexec  # noqa: F401
+from luxos.exceptions import MinerConnectionError
 from luxos.ips import load_ips_from_csv  # noqa: F401
+
+# TODO prepare for refactoring using example in
+#      tests.test_asyncops.test_bridge_execute_command
 from luxos.scripts.luxos import execute_command  # noqa: F401
+
+
+class LuxosLaunchError(MinerConnectionError):
+    pass
 
 
 def ip_ranges(
@@ -41,17 +50,35 @@ async def launch(
 ) -> Any:
     """launch an async function on a list of (host, port) miners
 
+    Special kwargs:
+        - batch execute operation in group of batch tasks (rate limiting)
+        - naked do not wrap the call (default None)
+
     Eg.
         async printme(host, port, value):
             print(await rexec(host, port, "version"))
         asyncio.run(launch([("127.0.0.1", 4028)], printme, value=11, batch=10))
     """
     # special kwargs!!
+    naked = kwargs.pop("naked") if "naked" in kwargs else None
+
+    def wraps(fn):
+        @functools.wraps(fn)
+        async def _fn(host: str, port: int):
+            try:
+                return await fn(host, port)
+            except Exception as exc:
+                raise LuxosLaunchError(host, port) from exc
+
+        return _fn
+
     n = int(kwargs.pop("batch") or 0) if "batch" in kwargs else None
     if n and n < 0:
         raise RuntimeError(
             f"cannot pass the 'batch' keyword argument with a value < 0: batch={n}"
         )
+    if not naked:
+        call = wraps(call)
 
     if n:
         result = []


### PR DESCRIPTION
## Description

Few issues emerged in post 0.0.8 release.

1. the log format should include a time stamp
2. utils.launch must standardize the exceptions returning the failed host info
3. update sample2.py example code

### new log format
The new log format (override-able on a per script base) will be:
```
2024-05-24 23:39:52,065 [I] luxos.cli.v1: py[3.11.9], luxos[/]
2024-05-24 23:39:52,066 [I] __main__: loading config from config.yaml
2024-05-24 23:39:52,067 [I] __main__: HELLO
2024-05-24 23:39:52,067 [I] luxos.cli.v1: task completed in 0.00s
```

### launch exceptions standardize
All the `luxos.utils.launch` returned exceptions will be reraised as LuxosLaunchError carrying the host/port informations.


## Merge request checklist

- [x] Added the appropriate `bug`, `enhancement` and/or `breaking-change` tags
- [x] My commits follow the [How to Write a Git Commit Message Guide](https://chris.beams.io/posts/git-commit/).
- [x] I have updated the `CHANGELOG` (yeah, last chance to do it).
- [x] My code passes all tests, linter and formatting checks:
      ```python make.pyz check```
      ```python make.pyz tests```
