### PR TITLE
restore old code for execute_command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help: ## Display the list of available targets
 
 
 .PHONY: check
-check: check-fmt lint test ## Check code formatting and run tests
+check: check-fmt lint ## Check code formatting
 	@echo "🟢 pass"
 
 .PHONY: check-fmt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "luxos"
-version = "0.1.0"
+version = "0.1.1"
 description = "The all encompassing LuxOS python library."
 readme = "README.md"
 license = { text = "MIT" }  # TODO I don't think this is a MIT??

--- a/src/luxos/cli/flags.py
+++ b/src/luxos/cli/flags.py
@@ -204,6 +204,9 @@ def add_arguments_database(parser: LuxosParserBase):
 
     group = parser.add_argument_group("database", "Database related options")
     group.add_argument("--db", dest="engine", help="sqlalchemy uri or filename")
+    group.add_argument(
+        "--db-create", action="store_true", help="create the db structures"
+    )
 
     def callback(args: argparse.Namespace):
         from sqlalchemy import create_engine

--- a/src/luxos/exceptions.py
+++ b/src/luxos/exceptions.py
@@ -32,3 +32,19 @@ class MinerCommandSessionAlreadyActive(MinerConnectionError):
 
 class MinerCommandMalformedMessageError(MinerConnectionError):
     pass
+
+
+class LuxosLaunchError(MinerConnectionError):
+    def __init__(self, tback: str, host: str, port: int, *args, **kwargs):
+        self.tback = tback
+        super().__init__(host, port, *args, **kwargs)
+
+    def __str__(self):
+        from .text import indent
+
+        msg = indent(str(self.tback), "| ")
+        return f"{self.address}: \n{msg}"
+
+
+class LuxosLaunchTimeoutError(LuxosLaunchError, asyncio.TimeoutError):
+    pass

--- a/src/luxos/ips.py
+++ b/src/luxos/ips.py
@@ -129,6 +129,27 @@ def iter_ip_ranges(
             cur += 1
 
 
+def ip_ranges(
+    txt: str, rsep: str = "-", gsep: str = ":"
+) -> list[tuple[str, int | None]]:
+    """return a list of ips given a text expression.
+
+    Eg.
+        >>> for ip in ip_ranges("127.0.0.1"):
+        ...     print(ip)
+        127.0.0.1
+
+        >>> for ip in ip_ranges("127.0.0.1-127.0.0.3"):
+        ...     print(ip)
+        127.0.0.1
+        127.0.0.2
+        127.0.0.3
+
+    NOTE: use the `:` (gsep) to separate ips groups, and `-` (rsep) to define a range.
+    """
+    return list(iter_ip_ranges(txt, rsep=rsep, gsep=gsep))
+
+
 def load_ips_from_csv(path: Path | str, port: int = 4028) -> list[tuple[str, int]]:
     """loads ip addresses from a csv file
 

--- a/src/luxos/scripts/luxos.py
+++ b/src/luxos/scripts/luxos.py
@@ -11,17 +11,9 @@ import argparse
 from pathlib import Path
 
 from ..cli import v1 as cli
+from ..syncops import execute_command
 
 log = logging.getLogger(__name__)
-
-
-def execute_command(host: str, port: int, timeout_sec: int, cmd: str, parameters: list, verbose: bool):
-    from ..asyncops import rexec
-    def adapter(awaitable):
-        with contextlib.suppress(asyncio.TimeoutError):
-            loop = asyncio.get_event_loop()
-            return loop.run_until_complete(awaitable)
-    return adapter(rexec(host, port, timeout=timeout_sec, cmd=cmd, parameters=parameters))
 
 
 def add_arguments(parser: cli.LuxosParserBase) -> None:

--- a/src/luxos/syncops.py
+++ b/src/luxos/syncops.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import json
+import logging
+import socket
+from typing import Any
+
+from luxos.api import logon_required
+
+log = logging.getLogger(__name__)
+
+
+# internal_send_cgminer_command sends a command to the
+# cgminer API server and returns the response.
+def internal_send_cgminer_command(
+    host: str, port: int, command: str, timeout_sec: int, verbose: bool
+) -> dict[str, Any]:
+    # Create a socket connection to the server
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            # set timeout
+            sock.settimeout(timeout_sec)
+
+            # Connect to the server
+            sock.connect((host, port))
+
+            # Send the command to the server
+            sock.sendall(command.encode())
+
+            # Receive the response from the server
+            response = bytearray()
+            while True:
+                # Read one byte at a time so we can wait for the null terminator.
+                # this is to avoid waiting for the timeout as we don't know how long
+                # the response will be and socket.recv() will block until reading
+                # the specified number of bytes.
+                try:
+                    data = sock.recv(1)
+                except socket.timeout:
+                    # Timeout occurred, check if we have any data so far
+                    if len(response) == 0:
+                        raise ValueError("timeout waiting for data")
+                    else:
+                        break
+                if not data:
+                    break
+                null_index = data.find(b"\x00")
+                if null_index >= 0:
+                    response += data[:null_index]
+                    break
+                response += data
+
+            # Parse the response JSON
+            r = json.loads(response.decode())
+            log.debug(r)
+            return r
+
+        except socket.error as e:
+            raise e
+
+
+# send_cgminer_command sends a command to the cgminer API server and
+# returns the response.
+def send_cgminer_command(
+    host: str, port: int, cmd: str, param: str, timeout: int, verbose: bool
+) -> dict[str, Any]:
+    req = str(f'{{"command": "{cmd}", "parameter": "{param}"}}\n')
+    log.debug(f"Executing command: {cmd} with params: {param} to host: {host}")
+
+    return internal_send_cgminer_command(host, port, req, timeout, verbose)
+
+
+# send_cgminer_simple_command sends a command with no params
+# to the miner and returns the response.
+def send_cgminer_simple_command(
+    host: str, port: int, cmd: str, timeout: int, verbose: bool
+) -> dict[str, Any]:
+    req = str(f'{{"command": "{cmd}"}}\n')
+    log.debug(f"Executing command: {cmd} to host: {host}")
+    return internal_send_cgminer_command(host, port, req, timeout, verbose)
+
+
+# check_res_structure checks that the response has the expected structure.
+def check_res_structure(
+    res: dict[str, Any], structure: str, min: int, max: int
+) -> dict[str, Any]:
+    # Check the structure of the response.
+    if structure not in res or "STATUS" not in res or "id" not in res:
+        raise ValueError("error: invalid response structure")
+
+    # Should we check min and max?
+    if min >= 0 and max >= 0:
+        # Check the number of structure elements.
+        if not (min <= len(res[structure]) <= max):
+            raise ValueError(
+                f"error: unexpected number of {structure} in response; "
+                f"min: {min}, max: {max}, actual: {len(res[structure])}"
+            )
+
+    # Should we check only min?
+    if min >= 0:
+        # Check the minimum number of structure elements.
+        if len(res[structure]) < min:
+            raise ValueError(
+                f"error: unexpected number of {structure} in response; "
+                f"min: {min}, max: {max}, actual: {len(res[structure])}"
+            )
+
+    # Should we check only max?
+    if max >= 0:
+        # Check the maximum number of structure elements.
+        if len(res[structure]) < min:
+            raise ValueError(
+                f"error: unexpected number of {structure} in response; "
+                f"min: {min}, max: {max}, actual: {len(res[structure])}"
+            )
+
+    return res
+
+
+# get_str_field tries to get the field as a string and returns it.
+def get_str_field(struct: dict[str, Any], name: str) -> str:
+    try:
+        s = str(struct[name])
+    except Exception as e:
+        raise ValueError(f"error: invalid {name} str field: {e}")
+
+    return s
+
+
+def logon(host: str, port: int, timeout: int, verbose: bool) -> str:
+    # Send 'logon' command to cgminer and get the response
+    res = send_cgminer_simple_command(host, port, "logon", timeout, verbose)
+
+    # Check if the response has the expected structure
+    check_res_structure(res, "SESSION", 1, 1)
+
+    # Extract the session data from the response
+    session = res["SESSION"][0]
+
+    # Get the 'SessionID' field from the session data
+    s = get_str_field(session, "SessionID")
+
+    # If 'SessionID' is empty, raise an error indicating invalid session id
+    if s == "":
+        raise ValueError("error: invalid session id")
+
+    # Return the extracted 'SessionID'
+    return s
+
+
+def add_session_id_parameter(session_id, parameters):
+    # Add the session id to the parameters
+    return [session_id, *parameters]
+
+
+def parameters_to_string(parameters):
+    # Convert the parameters to a string that LuxOS API accepts
+    return ",".join(parameters)
+
+
+def execute_command(
+    host: str, port: int, timeout_sec: int, cmd: str, parameters: list, verbose: bool
+):
+    # Check if logon is required for the command
+    logon_req = logon_required(cmd)
+
+    try:
+        if logon_req:
+            # Get a SessionID
+            sid = logon(host, port, timeout_sec, verbose)
+            # Add the SessionID to the parameters list at the left.
+            parameters = add_session_id_parameter(sid, parameters)
+
+            log.debug("Command requires a SessionID, logging in for host: %s", host)
+            log.info("SessionID obtained for %s: %s", host, sid)
+
+        # TODO verify this
+        elif not logon_required:  # type: ignore
+            log.debug("Logon not required for executing %s", cmd)
+
+        # convert the params to a string that LuxOS API accepts
+        param_string = parameters_to_string(parameters)
+
+        log.debug("%s on %s with parameters: %s", cmd, host, param_string)
+
+        # Execute the API command
+        res = send_cgminer_command(host, port, cmd, param_string, timeout_sec, verbose)
+
+        log.debug(res)
+
+        # Log off to terminate the session
+        if logon_req:
+            send_cgminer_command(host, port, "logoff", sid, timeout_sec, verbose)
+
+        return res
+
+    except Exception:
+        log.exception("Error executing %s on %s", cmd, host)

--- a/src/luxos/utils.py
+++ b/src/luxos/utils.py
@@ -11,48 +11,13 @@ import luxos.misc
 from luxos.asyncops import rexec  # noqa: F401
 
 # we bring here functions from other modules
-from luxos.exceptions import MinerConnectionError
-from luxos.ips import load_ips_from_csv  # noqa: F401
-from luxos.scripts.luxos import execute_command  # noqa: F401
-
-
-class LuxosLaunchError(MinerConnectionError):
-    def __init__(self, tback: str, host: str, port: int, *args, **kwargs):
-        self.tback = tback
-        super().__init__(host, port, *args, **kwargs)
-
-    def __str__(self):
-        from .text import indent
-
-        msg = indent(str(self.tback), "| ")
-        return f"{self.address}: \n{msg}"
-
-
-class LuxosLaunchTimeoutError(LuxosLaunchError, asyncio.TimeoutError):
-    pass
-
-
-def ip_ranges(
-    txt: str, rsep: str = "-", gsep: str = ":"
-) -> list[tuple[str, int | None]]:
-    """return a list of ips given a text expression.
-
-    Eg.
-        >>> for ip in ip_ranges("127.0.0.1"):
-        ...     print(ip)
-        127.0.0.1
-
-        >>> for ip in ip_ranges("127.0.0.1-127.0.0.3"):
-        ...     print(ip)
-        127.0.0.1
-        127.0.0.2
-        127.0.0.3
-
-    NOTE: use the `:` (gsep) to separate ips groups, and `-` (rsep) to define a range.
-    """
-    from .ips import iter_ip_ranges
-
-    return list(iter_ip_ranges(txt, rsep=rsep, gsep=gsep))
+from luxos.exceptions import (  # noqa: F401
+    LuxosLaunchError,
+    LuxosLaunchTimeoutError,
+    MinerConnectionError,
+)
+from luxos.ips import ip_ranges, load_ips_from_csv  # noqa: F401
+from luxos.syncops import execute_command  # noqa: F401
 
 
 async def launch(

--- a/tests/test_syncops.py
+++ b/tests/test_syncops.py
@@ -1,0 +1,99 @@
+import random
+from string import ascii_lowercase
+
+import pytest
+
+from luxos import exceptions, syncops
+
+pytestmark = pytest.mark.manual
+
+
+def test_miner_logon_logoff_cycle(miner_host_port):
+    host, port = miner_host_port
+
+    sid = None
+    try:
+        sid = syncops.logon(host, port)
+    except exceptions.MinerCommandSessionAlreadyActive as e:
+        raise RuntimeError("a session is already active on {host}:{port}") from e
+    finally:
+        if sid:
+            syncops.logoff(host, port, sid)
+
+
+def test_miner_double_logon_cycle(miner_host_port):
+    host, port = miner_host_port
+
+    sid = syncops.logon(host, port)
+    try:
+        with pytest.raises(exceptions.MinerCommandSessionAlreadyActive) as excinfo:
+            syncops.logon(host, port)
+        assert excinfo.value.args[0] == f"session active for {host}:{port}"
+    except Exception:
+        pass
+    finally:
+        if sid:
+            syncops.logoff(host, port, sid)
+
+
+def test_miner_version(miner_host_port):
+    host, port = miner_host_port
+
+    res = syncops.execute_command(host, port, None, "version")
+    assert "VERSION" in res
+    assert len(res["VERSION"]) == 1
+    assert "API" in res["VERSION"][0]
+
+
+def test_atm_flip(miner_host_port):
+    host, port = miner_host_port
+
+    def getatm():
+        res = syncops.execute(host, port, "atm")
+        return syncops.validate_message(host, port, res, "ATM")[0]["Enabled"]
+
+    # current status
+    status = getatm()
+    assert status in {True, False}
+
+    # check we can set the atm to the same status
+    syncops.execute(host, port, "atmset", {"enabled": status})
+    assert status == getatm()
+
+    syncops.execute(host, port, "atmset", {"enabled": not status})
+    assert status != getatm()
+
+    syncops.execute(host, port, "atmset", {"enabled": not getatm()})
+    assert status == getatm()
+
+
+def test_miner_profile_sets(miner_host_port):
+    host, port = miner_host_port
+
+    # random profile name
+    profile = f"test-{''.join(random.choices(ascii_lowercase, k=5))}"
+    profiles = syncops.execute(host, port, "profiles")["PROFILES"]
+    # verify profile is not present
+    assert profiles and profile not in {p["Profile Name"] for p in profiles}
+
+    # # create a new profile
+    # # TODO there's a bug
+    # #  when ATM is running you shouldn't be able to create/delete
+    # #  profiles, the following test should fail at the first try
+    # # -> to pass this test, you need to disable ATM
+    #
+    params = f"{profile},{profiles[0]['Frequency']},{profiles[0]['Voltage']}"
+    syncops.execute(host, port, "profilenew", params)
+
+    try:
+        profiles1 = (syncops.execute(host, port, "profiles"))["PROFILES"]
+        assert profile in {p["Profile Name"] for p in profiles1}
+    finally:
+        with syncops.with_atm(host, port, False):
+            syncops.execute(host, port, "profilerem", profile)
+
+    # verify we restored the same profiles
+    profiles2 = (syncops.execute(host, port, "profiles"))["PROFILES"]
+    found = {p["Profile Name"] for p in profiles2}
+    expected = {p["Profile Name"] for p in profiles}
+    assert found == expected

--- a/tests/test_syncops.py
+++ b/tests/test_syncops.py
@@ -39,7 +39,7 @@ def test_miner_double_logon_cycle(miner_host_port):
 def test_miner_version(miner_host_port):
     host, port = miner_host_port
 
-    res = syncops.execute_command(host, port, None, "version")
+    res = syncops.rexec_command(host, port, None, "version")
     assert "VERSION" in res
     assert len(res["VERSION"]) == 1
     assert "API" in res["VERSION"][0]
@@ -49,7 +49,7 @@ def test_atm_flip(miner_host_port):
     host, port = miner_host_port
 
     def getatm():
-        res = syncops.execute(host, port, "atm")
+        res = syncops.rexec(host, port, "atm")
         return syncops.validate_message(host, port, res, "ATM")[0]["Enabled"]
 
     # current status
@@ -57,13 +57,13 @@ def test_atm_flip(miner_host_port):
     assert status in {True, False}
 
     # check we can set the atm to the same status
-    syncops.execute(host, port, "atmset", {"enabled": status})
+    syncops.rexec(host, port, "atmset", {"enabled": status})
     assert status == getatm()
 
-    syncops.execute(host, port, "atmset", {"enabled": not status})
+    syncops.rexec(host, port, "atmset", {"enabled": not status})
     assert status != getatm()
 
-    syncops.execute(host, port, "atmset", {"enabled": not getatm()})
+    syncops.rexec(host, port, "atmset", {"enabled": not getatm()})
     assert status == getatm()
 
 
@@ -72,7 +72,7 @@ def test_miner_profile_sets(miner_host_port):
 
     # random profile name
     profile = f"test-{''.join(random.choices(ascii_lowercase, k=5))}"
-    profiles = syncops.execute(host, port, "profiles")["PROFILES"]
+    profiles = syncops.rexec(host, port, "profiles")["PROFILES"]
     # verify profile is not present
     assert profiles and profile not in {p["Profile Name"] for p in profiles}
 
@@ -83,17 +83,17 @@ def test_miner_profile_sets(miner_host_port):
     # # -> to pass this test, you need to disable ATM
     #
     params = f"{profile},{profiles[0]['Frequency']},{profiles[0]['Voltage']}"
-    syncops.execute(host, port, "profilenew", params)
+    syncops.rexec(host, port, "profilenew", params)
 
     try:
-        profiles1 = (syncops.execute(host, port, "profiles"))["PROFILES"]
+        profiles1 = (syncops.rexec(host, port, "profiles"))["PROFILES"]
         assert profile in {p["Profile Name"] for p in profiles1}
     finally:
         with syncops.with_atm(host, port, False):
-            syncops.execute(host, port, "profilerem", profile)
+            syncops.rexec(host, port, "profilerem", profile)
 
     # verify we restored the same profiles
-    profiles2 = (syncops.execute(host, port, "profiles"))["PROFILES"]
+    profiles2 = (syncops.rexec(host, port, "profiles"))["PROFILES"]
     found = {p["Profile Name"] for p in profiles2}
     expected = {p["Profile Name"] for p in profiles}
     assert found == expected


### PR DESCRIPTION
## Description

Restore the old execute_command code.
```
from luxos import utils
utils.execute_command("10.0.0.1", 4028, 2, "version", "", True)
```

There's a new (sync) rexec function:
```
from luxos import syncops, asyncops

print(syncops.rexec(host, port, "version"))
print(await asyncops.rexec(host, port, "version"))
```
> **NOTE** the sync version doesn't support retry


- **Makefile** - clean the check target removing the tests (separate task)
- **pyproject.toml** - version bump
- **asyncops**
   - `validate_message` defaults check validate a single item result
   - `logon/logoff` fallback to module level TIMEOUT
   - `execute_command` removed
   - renamed `_rexec_parameters` -> `parameters_to_list`
   - `with_atm` - new context manager for operation needing disabling atm (eg. profileset)
- **flags** - added a --db-create to db flag
- **exception** - moved LuxosLaunchError/LuxosLaunchTimeoutError from utils
- **ips** - moved ip_ranges from utils
- **luxos** - moved `execute_command` in syncops module
- **syncops** - new sync module mirroring the asyncops
- **utils** - code refactoring (no api change)


## Merge request checklist

- [x] Added the appropriate `bug`, `enhancement` and/or `breaking-change` tags
- [x] My commits follow the [How to Write a Git Commit Message Guide](https://chris.beams.io/posts/git-commit/).
- [x] I have updated the `CHANGELOG` (yeah, last chance to do it).
- [x] My code passes all tests, linter and formatting checks:
      ```make check```
      ```make test```
