### PR TITLE
reduce dependencies and improve version information log

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Mypy](https://img.shields.io/badge/types-Mypy-blue.svg)](https://mypy-lang.org/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-This package contains a python package `luxos` and scripts to operate miners running LuxOS. See the
+This package contains the `luxos` python package: a collection of scripts and api to operate miners running LuxOS. See the
 full documentation [here](https://luxorlabs.github.io/luxos-tooling).
 
 ## Install
@@ -16,17 +16,52 @@ full documentation [here](https://luxorlabs.github.io/luxos-tooling).
 To install the latest version:
 ```bash
    $> pip install -U luxos
+
+   # to install the extra features
+   $> pip install -U luxos[extra]
 ```
 
-Check the version:
+You can check the version:
 ```bash
-python -c "import luxos; print(luxos.__version__, luxos.__hash__)"
-# 0.0.5 08cc733ce8aedf406856c8ad9ccbe44e78917a37
+python -c "import luxos.version; print(luxos.version.get_version())"
+py[3.13.0rc2], luxos[0.2.4, 08cc733ce]
 ```
+
+## Api usage
+
+### rexec/validate
+
+The [luxos](https://pypi.org/project/luxos) has an extremely simple api.
+
+For example to retrive the version info from a miner:
+```
+import asyncio
+from luxos.asyncops import rexec, validate
+
+# for a miner at 127.0.0.1 listening to port 4028 (the default)
+res = await rexec("127.0.0.1", 4028, "version")
+print(validate(res, "VERSION", 1, 1))
+
+{'API': '3.7', 'CompileTime': 'Tue Sep 17 17:49:18 UTC 2024', 'LUXminer': '2024.9.17.174900-4631c4d1', 'Miner': '2024.9.17.174900', 'Type': 'Antminer S19'}
+```
+> **NOTE** The above should be executed using `python3 -m asyncio` instead `python3`.
+
+For a syncronous version (eg. not using asyncio):
+```
+import asyncio
+from luxos.syncops import rexec, validate
+res = rexec("127.0.0.1", 4028, "version")
+print(validate(res, "VERSION", 1, 1))  # validate makes sure you the correct message and returns one dictionary
+```
+Yes, it only needs to import `luxos.syncops` instead `luxos.asyncops`, the api is similar (minus the async/await).
+
+> **NOTE** the [rexec](https://luxorlabs.github.io/luxos-tooling/api/luxos.asyncops.html#luxos.asyncops.rexec) function supports also
+timeouts and retry.
+> The [validate](https://luxorlabs.github.io/luxos-tooling/api/luxos.asyncops.html#luxos.asyncops.validate) check the result.
 
 ## Scripting
 
-The [luxos](https://pypi.org/project/luxos) package comes with some helper
+[luxos](https://pypi.org/project/luxos) comes with some helper
 scripts, to ease everyday miners' maintenance.
 
 ### luxos (cli)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,24 @@ timeouts and retry.
 
 ### launch
 
-TBD
+The [launch](https://luxorlabs.github.io/luxos-tooling/api/luxos.utils.html#luxos.utils.launch) command can launch an arbitrary function
+across many miners leveraging asyncio for performance.
+
+```
+from luxos import utils, ips
+
+# we'll execute and return the "version" command on miners
+async def version(host, port):
+    res = await utils.rexec(host, port, "version")
+    return utils.validate(res, "VERSION", 1, 1)
+
+# load miners ip addresses from a csv file
+addresses = addresses = ips.load_ips_from_csv("miners.csv")
+
+# run 50 version function in parallel
+print(await utils.launch(addresses, version, batch=50))
+[{'API': '3.7', 'CompileTime': 'Tue Sep 17 17:49:18 UTC 2024', 'LUXminer': '2024.9.17.174900-4631c4d1', 'Miner': '2024.9.17.174900', 'Type': 'Antminer S19'}]
+```
 
 ## Scripting
 
@@ -110,31 +127,6 @@ This will run `my-script.py` and report the results in json:
 ```shell
 luxos-run --range 127.0.0.1 my-script.py
 ```
-
-### Get a miner's version (example)
-
-Get a miner's version data (async version):
-```python
-import asyncio
-from luxos.utils import rexec, validate
-
-async def get_version(host: str, port: int) -> dict:
-    res = await rexec(host, port, "version")
-    return validate(res, "VERSION", 1, 1)
-
-if __name__ == "__main__":
-    print(asyncio.run(get_version("127.0.0.1", 4028)))
-```
-
-There's a syncronous version (better for one-liners), with identical calling conventions:
-```python
-from luxos.utils import execute_command, validate, load_ips_from_csv
-
-if __name__ == "__main__":
-    print(validate(execute_command(
-        "127.0.0.1", 4028, 3, "version"), "VERSION", 1, 1))
-```
-
 
 ## LuxOS HealthChecker - health_checker.py
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ py[3.13.0rc2], luxos[0.2.4, 08cc733ce]
 
 ## Api usage
 
+[luxos](https://pypi.org/project/luxos) provides an API in both sync and async 
+version: [full documentation here](https://luxorlabs.github.io/luxos-tooling).
+
 ### rexec/validate
 
 The [luxos](https://pypi.org/project/luxos) has an extremely simple api.
@@ -58,6 +61,10 @@ Yes, it only needs to import `luxos.syncops` instead `luxos.asyncops`, the api i
 > **NOTE** the [rexec](https://luxorlabs.github.io/luxos-tooling/api/luxos.asyncops.html#luxos.asyncops.rexec) function supports also
 timeouts and retry.
 > The [validate](https://luxorlabs.github.io/luxos-tooling/api/luxos.asyncops.html#luxos.asyncops.validate) check the result.
+
+### launch
+
+TBD
 
 ## Scripting
 
@@ -104,27 +111,6 @@ This will run `my-script.py` and report the results in json:
 luxos-run --range 127.0.0.1 my-script.py
 ```
 
-## API
-
-[luxos](https://pypi.org/project/luxos) provides an easy-to-use API to
-write complex scripts on miners.
-
-It comes in two different flavours, a sync version for legacy non high performance
-operations, and an async version allowing operation on a fleet of miners: the API
-of the main functions is essentially keep identical.
-
-### Main functions
-
-The whole of the "*kernel*" API is rather small-ish and it is based 
-essentially on few functions:
-- **luxos.utils.load_ips_from_csv** - utility to load miners addresses from a CSV file
-- **luxos.utils.rexec** - an async function to launch commands on a miner
-- **luxos.utils.execute_command** - the same as rexec but syncronous
-- **luxos.utils.validate** - validate a message from a miner
-- **luxos.utils.launch** - run a command on multiple miners
-
-[Full documentation](https://luxorlabs.github.io/luxos-tooling).
-
 ### Get a miner's version (example)
 
 Get a miner's version data (async version):
@@ -149,27 +135,6 @@ if __name__ == "__main__":
         "127.0.0.1", 4028, 3, "version"), "VERSION", 1, 1))
 ```
 
-
-### Run commands  (example)
-
-The `luxos.utils.launch` is an async function to launch a command on a
-set of miners using asyncio.
-
-This is a simple example (see [Full documentation](https://luxorlabs.github.io/luxos-tooling))
-for more.
-
-```python
-import asyncio
-from luxos.utils import validate, load_ips_from_csv, rexec, launch
-
-async def get_version(host: str, port: int) -> dict:
-    res = await rexec(host, port, "version")
-    return validate(res, "VERSION", 1, 1)
-
-if __name__ == "__main__":
-    addresses = load_ips_from_csv("miners.csv")
-    print(asyncio.run(launch(addresses, get_version)))
-```
 
 ## LuxOS HealthChecker - health_checker.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,18 +27,15 @@ classifiers = [
 ]
 
 dependencies = [
-  "tqdm",
-  "asyncpg",
-  "pandas",
-  "pyyaml",
-  "httpx"
+    "pyyaml",
 ]
 
 [project.optional-dependencies]
 extra = [
-    "tqdm",
-    "pandas",
     "asyncpg",
+    "httpx",
+    "pandas",
+    "tqdm",
 ]
 
 [project.urls]

--- a/src/luxos/version.py
+++ b/src/luxos/version.py
@@ -8,11 +8,14 @@ __version__ = ""
 __hash__ = ""
 
 
-def get_version_info(modules: list[types.ModuleType] | None = None) -> dict[str, str]:
+def get_version_info(
+    modules: list[types.ModuleType] | None = None, short: bool = False
+) -> dict[str, str]:
     result = {
         "py": sys.version.partition(" ")[0],
         "luxos": ", ".join(
-            str(c) if str(c) else "N/A" for c in [__version__, __hash__]
+            str(c) if str(c) else "N/A"
+            for c in [__version__, __hash__[:7] if short else __hash__]
         ),
     }
 
@@ -32,4 +35,6 @@ def get_version_info(modules: list[types.ModuleType] | None = None) -> dict[str,
 
 
 def get_version(modules: list[types.ModuleType] | None = None) -> str:
-    return ", ".join(f"{k}[{v}]" for k, v in get_version_info().items())
+    return ", ".join(
+        f"{k}[{v}]" for k, v in get_version_info(modules, short=True).items()
+    )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,8 @@
-asyncpg
+# base (from pyproject.toml)
+pyyaml
+
+# all test deps
 build
-httpx
 lxml
 mypy
 pre-commit
@@ -9,7 +11,6 @@ pytest-asyncio
 pytest-cov
 pytest-html
 pyyaml
+ruff
 types-python-dateutil
 types-pyyaml
-ruff
-mypy

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,10 +10,12 @@ from luxos import version
 PYVERSION = sys.version.partition(" ")[0]
 
 VALUES = [
+    # version, hash, expected
     ("", "", "N/A, N/A"),
     ("1.2.3", "", "1.2.3, N/A"),
     ("1.2.3", "abcdef", "1.2.3, abcdef"),
     ("", "abcdef", "N/A, abcdef"),
+    ("", "1234567XXXX", "N/A, 1234567"),  # hash is truncated to 7chars
 ]
 
 
@@ -24,7 +26,7 @@ def test_no_extra_modules(mversion, mhash, expected):
         stack.enter_context(mock.patch("luxos.version.__hash__", mhash))
         assert version.get_version_info() == {
             "py": PYVERSION,
-            "luxos": expected,
+            "luxos": f"{mversion or 'N/A'}, {mhash or 'N/A'}",
         }
         assert version.get_version() == f"py[{PYVERSION}], luxos[{expected}]"
 


### PR DESCRIPTION
## Description
This change:
- moves dependencies to the extra option
- reports version and git hash information for luxos scripts.

Example:
```
$> PYTHONPATH=src python -m luxos.scripts.luxos --range 10.206.0.22 --command version
2024-09-25 13:52:56,346 [I] luxos.cli.v1: py[3.13.0rc2], luxos[N/A, N/A]
```
(in a deployed luxos, N/A will be replace with the appropriate version).
.

## Merge request checklist

- [x] Added the appropriate `bug`, `enhancement` and/or `breaking-change` tags
- [x] My commits follow the [How to Write a Git Commit Message Guide](https://chris.beams.io/posts/git-commit/).
- [x] I have updated the `CHANGELOG` (yeah, last chance to do it).
- [x] My code passes all tests, linter and formatting checks:
      ```make check```
      ```make test```
