### PR TITLE
CI: Add publish to GitHub release page logic

### DIFF
--- a/.github/workflows/pull-python-luxos.yml
+++ b/.github/workflows/pull-python-luxos.yml
@@ -1,10 +1,9 @@
 name: LuxOS Pull-Request
 
 on:
-  workflow_dispatch:
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    branches:
+      - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/pull-python-luxos.yml
+++ b/.github/workflows/pull-python-luxos.yml
@@ -1,9 +1,10 @@
 name: LuxOS Pull-Request
 
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
+  # pull_request:
+  #   branches:
+  #     - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -90,6 +90,19 @@ jobs:
           ls -la build
           ls -la dist
 
+      - name: Upload to GitHub Release
+        if: ${{ (matrix.python-version == env.XPY) && (matrix.os == env.XOS) }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ env.PACKAGE }}-${{ github.run_number }}
+          name: Release v${{ env.PACKAGE }}-${{ github.run_number }}
+          prerelease: true
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # - name: "Publish beta package to pypi"
       #   uses: pypa/gh-action-pypi-publish@release/v1
       #   if: ${{ (matrix.python-version == env.XPY) && (matrix.os == env.XOS) }}

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -1,11 +1,13 @@
 name: Master build
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - '*'
+  pull_request:
+    types: [opened, synchronize, reopened]
+  # push:
+  #   branches:
+  #     - main
+  #   tags:
+  #     - '*'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -83,20 +85,23 @@ jobs:
         run: |
           python support/release.py src/luxos/version.py
           touch .keepme
+          pwd
+          ls -la
+          ls -la build
 
-      - name: "Publish beta package to pypi"
-        uses: pypa/gh-action-pypi-publish@release/v1
-        if: ${{ (matrix.python-version == env.XPY) && (matrix.os == env.XOS) }}
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      # - name: "Publish beta package to pypi"
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   if: ${{ (matrix.python-version == env.XPY) && (matrix.os == env.XOS) }}
+      #   with:
+      #     password: ${{ secrets.PYPI_API_TOKEN }}
 
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: qa-results-${{ matrix.python-version }}-${{ matrix.os }}
-          path: |
-            build/qa-${{ matrix.python-version }}-${{ matrix.os}}
-            dist
-            .keepme
-        # Use always() to always run this step to publish test results when there are test failures
-        if: always()
+      # - name: Archive artifacts
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: qa-results-${{ matrix.python-version }}-${{ matrix.os }}
+      #     path: |
+      #       build/qa-${{ matrix.python-version }}-${{ matrix.os}}
+      #       dist
+      #       .keepme
+      #   # Use always() to always run this step to publish test results when there are test failures
+      #   if: always()

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -85,18 +85,20 @@ jobs:
         run: |
           python support/release.py src/luxos/version.py
           touch .keepme
-          pwd
-          ls -la
-          ls -la build
-          ls -la dist
+
+      - name: Extract version
+        id: get_version
+        run: |
+          VERSION=$(grep '^version =' pyproject.toml | sed -E "s/version = \"([^\"]+)\"/\1/")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Upload to GitHub Release
         if: ${{ (matrix.python-version == env.XPY) && (matrix.os == env.XOS) }}
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ env.PACKAGE }}-${{ github.run_number }}
-          name: Release v${{ env.PACKAGE }}-${{ github.run_number }}
-          prerelease: true
+          tag_name: v${{ steps.get_version.outputs.version }}
+          name: Release v${{ steps.get_version.outputs.version }}
+          prerelease: false
           files: |
             dist/*.whl
             dist/*.tar.gz

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -88,6 +88,7 @@ jobs:
           pwd
           ls -la
           ls -la build
+          ls -la dist
 
       # - name: "Publish beta package to pypi"
       #   uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -1,13 +1,11 @@
 name: Master build
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  # push:
-  #   branches:
-  #     - main
-  #   tags:
-  #     - '*'
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
## Description

- This PR modifies the push-main workflow, adds the logic to upload artifacts to the GitHub release page
- Here is the recent successful run - https://github.com/LuxorLabs/luxos-tooling/releases

## Merge request checklist

- [X] Added the appropriate `bug`, `enhancement` and/or `breaking-change` tags
- [ ] My commits follow the [How to Write a Git Commit Message Guide](https://chris.beams.io/posts/git-commit/).
- [ ] I have updated the `CHANGELOG` (yeah, last chance to do it).
- [ ] My code passes all tests, linter and formatting checks:
      ```make check```
      ```make test```
